### PR TITLE
add OSI as contributing organization in AUTHORS.md

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -22,3 +22,4 @@ We thank the list of organisations that have contributed to this policy:
 
 * United States Government Office of the Chief Information Officer
 
+* Open Source Initiative (OSI)


### PR DESCRIPTION
rationale: I've myself represented the organization during activivities of the initial the working group