### PR TITLE
OGP is in the past now

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
  
 ## Context
 
-This template policy is drafted for the Open Government Partnership Summit that will take place in Paris, December 7-9, 2017.
+This template policy was drafted for the Open Government Partnership Summit that took place in Paris, December 7-9, 2016.
 https://fr.ogpsummit.org/osem/conference/ogp-summit/program/proposal/74
 
 Discussions around this open-source policy are available here:


### PR DESCRIPTION
...unless I'm mistaken. The README currently refers to OGP 2017, but, even taking into consideration the links, I'm sort of assuming that's a typo. If it is, then OGP Summit references should be in the past tense now, which can be done by merging this pull request.